### PR TITLE
add unit test for bibs

### DIFF
--- a/src/tests/test.py
+++ b/src/tests/test.py
@@ -28,7 +28,7 @@ def test_xml_string():
 
 def test_volumes_exist():
     # check that there's a volume directory
-    for i in range(11, 21):
+    for i in range(6, 26):
         assert os.path.exists(f"output/papers/volume{i}/")
 
 def paper_iterator(volume, prefix):
@@ -101,22 +101,20 @@ def test_paper_metadata(volume, prefix):
         assert citation_authors == set_authors
 
 
-# Failing, commenting out for now
-# @pytest.mark.parametrize("volume", all_volumes)
-# @pytest.mark.parametrize("prefix", PREFIXES)
-# def test_paper_bibtex(volume, prefix):
-#     """Check that authors coincide with the bibtex"""
-#     for soup, info in paper_iterator(volume, prefix):
-#         set_authors = set([utils.xml_string(c) for c in info['authors']])
+@pytest.mark.parametrize("volume", all_volumes)
+@pytest.mark.parametrize("prefix", PREFIXES)
+def test_paper_bibtex(volume, prefix):
+    """Check that authors coincide with the bibtex"""
+    for soup, info in paper_iterator(volume, prefix):
+        set_authors = set([utils.xml_string(c) for c in info['authors']])
 
-#         parser = BibTexParser()
-#         parser.customization = convert_to_unicode
-#         out_bib = 'output' + prefix + 'papers/v%s/%s.bib' % (volume, info['id'])
-#         with open(out_bib) as f:
-#             bib_database = bibtexparser.load(f, parser=parser)
-#         authors_bib = set([u.strip() for u in bib_database.entries[0]['author'].split(' and ')])
+        parser = BibTexParser()
+        out_bib = 'output' + prefix + 'papers/v%s/%s.bib' % (volume, info['id'])
+        with open(out_bib) as f:
+            bib_database = bibtexparser.load(f, parser=parser)
+        authors_bib = set([utils.xml_string(u.strip()) for u in bib_database.entries[0]['author'].split(' and ')])
 
-#         assert authors_bib == set_authors
+        assert authors_bib == set_authors
 
 
 @pytest.mark.parametrize("volume", all_volumes)


### PR DESCRIPTION
# Description
1. **Tests for bibs are available.**  
	The reasony why tests for bib files kept failing is that there were some unfixed typos in the bib files, rather than not treating the accents right (mentioned in #9). PR #86 and #87 fixed those typos. 
![testres](https://github.com/user-attachments/assets/9754b07f-3487-4f18-93e0-3bcb6ebe6150)
