### PR TITLE
fixed RSS pubDate format to be RFC 2822

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,7 @@ import json
 import glob
 import shutil
 import re
+import datetime
 
 # this are combinations of the form example: {{\\'o}}
 accents = [
@@ -141,6 +142,11 @@ def get_info(vol):
             id_info["authors_list"] = [
                 author_string(u.strip()) for u in id_info["authors"]
             ]
+
+            # ensure date format is RFC 2822 for RSS feed
+            id_info["date"] = datetime.datetime.strptime(
+                str(id_info["year"]), "%Y"
+            ).strftime("%a, %d %b %Y %H:%M:%S")
 
         info_list.append(id_info)
     os.chdir("..")

--- a/templates/jmlr.xml
+++ b/templates/jmlr.xml
@@ -20,7 +20,7 @@ http://jmlr.org/papers/v{{paper.volume}}/{{paper.id}}.html
 <pdf>
 http://jmlr.org/papers/volume{{paper.volume}}/{{paper.id}}/{{paper.id}}.pdf
 </pdf>
-<pubDate>{{paper.year}}</pubDate>
+<pubDate>{{paper.date}}</pubDate>
 <author>{{paper.authors_string}}</author>
 <description>
 {{paper.abstract}}


### PR DESCRIPTION
Currently some RSS readers do not properly render the date for articles as the format is just the year `%Y`. This PR fixes that by ensuring the `pubDate` format is RFC 2822 (Thu, 01 Jan 2026 00:00:00, `%a, %d %b %Y %H:%M:%S`).